### PR TITLE
[main] ensure 51-day price history

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+exclude = venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv/
+__pycache__/

--- a/main.py
+++ b/main.py
@@ -5,12 +5,12 @@ from kiwoom_api import KiwoomAPI
 from indicators import calculate_sma, calculate_rsi_wilder
 from strategy import select_candidates
 from utils import save_to_csv
-import pandas as pd
+
 
 def main():
     """
     1) KOSPI 시장 종목 코드 수집
-    2) 종목별 과거 50거래일 종가 데이터 요청
+    2) 종목별 과거 51거래일 이상 종가 데이터 요청
     3) MA20, MA50, RSI 계산
     4) 매수 후보 분류 (A/B/C 그룹)
     5) 후보 CSV 저장
@@ -35,18 +35,22 @@ def main():
         # 진행 상황 출력
         print(f"[{idx}/{len(codes)}] 코드: {code} 데이터 수집 중...")
 
-        # 1) 과거 50일 종가 데이터 요청
-        df_price = api.get_price_data(code, count=50)
-        if df_price is None:
+        # 1) 과거 51일 이상 종가 데이터 요청
+        df_price = api.get_price_data(code, count=51)
+        if df_price is None or len(df_price) < 51:
             print(f"[Warning] {code} 데이터 부족 또는 오류")
             continue
 
         # 2) 이동평균(MA20, MA50) 계산
-        df_price['MA20'] = calculate_sma(df_price['Close'], 20)  # 책 13장 SMA 참조 :contentReference[oaicite:37]{index=37}
-        df_price['MA50'] = calculate_sma(df_price['Close'], 50)
+        df_price["MA20"] = calculate_sma(
+            df_price["Close"], 20
+        )  # 책 13장 SMA 참조 :contentReference[oaicite:37]{index=37}
+        df_price["MA50"] = calculate_sma(df_price["Close"], 50)
 
         # 3) RSI 계산 (Wilder SMMA)
-        df_price['RSI'] = calculate_rsi_wilder(df_price['Close'], 14)  # 책 13장 RSI 참조 :contentReference[oaicite:38]{index=38}
+        df_price["RSI"] = calculate_rsi_wilder(
+            df_price["Close"], 14
+        )  # 책 13장 RSI 참조 :contentReference[oaicite:38]{index=38}
 
         # 4) 종목명 수집
         name = api.get_stock_name(code)
@@ -65,6 +69,7 @@ def main():
     # 7) 결과 저장
     print("[Info] 후보 리스트 저장 중...")
     save_to_csv(candidates, base_filename="candidates")
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,0 +1,42 @@
+import pandas as pd
+
+from strategy import select_candidates
+
+
+def make_df(group: str) -> pd.DataFrame:
+    """Return DataFrame of length 51 to trigger a specific group."""
+
+    close = [100] * 51
+    if group == "A":
+        ma20 = [1] * 50 + [2]
+        ma50 = [1] * 51
+        rsi = [50] * 50 + [40]  # not oversold
+    elif group == "B":
+        ma20 = [1] * 51
+        ma50 = [1] * 51
+        rsi = [50] * 50 + [20]  # oversold only
+    else:  # group C
+        ma20 = [1] * 50 + [2]
+        ma50 = [1] * 51
+        rsi = [50] * 50 + [20]
+
+    return pd.DataFrame(
+        {
+            "Close": close,
+            "MA20": ma20,
+            "MA50": ma50,
+            "RSI": rsi,
+        }
+    )
+
+
+def test_select_candidates_group_c():
+    df = make_df("C")
+    result = select_candidates("000000", "TEST", df)
+    assert result is not None
+    assert result["group"] == "C"
+
+
+def test_select_candidates_insufficient():
+    df = make_df("A").iloc[:50]
+    assert select_candidates("000000", "TEST", df) is None


### PR DESCRIPTION
## Summary
- request at least 51 days of price data in main workflow
- check length before calling the strategy
- add simple strategy tests for valid and insufficient data
- ignore local venv in linting

## Testing
- `flake8 | head -n 5`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f3e63214832f8776c8fe2bb71aed