### PR TITLE
[scheduler] daily APScheduler setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # kiwoom_auto_trading_with_selector
+
 kiwoom_auto_trading_with_selector
+
+## Scheduler
+
+`scheduler.py` uses APScheduler to invoke `main.main()` once per weekday after the Korean market closes.
+Run the scheduler with:
+
+```bash
+python scheduler.py
+```
+
+The job is scheduled at **16:05 KST** Monday through Friday and will keep running until stopped.

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,25 @@
+"""Scheduler setup for daily job"""
+
+from apscheduler.schedulers.blocking import BlockingScheduler
+from apscheduler.triggers.cron import CronTrigger
+from zoneinfo import ZoneInfo
+
+import main
+
+
+def start():
+    """Start APScheduler that runs main.main() each weekday after market close."""
+    tz = ZoneInfo("Asia/Seoul")
+    scheduler = BlockingScheduler(timezone=tz)
+    # Run at 16:05 Korea time Monday through Friday
+    trigger = CronTrigger(day_of_week="mon-fri", hour=16, minute=5, timezone=tz)
+    scheduler.add_job(main.main, trigger)
+    print("[Scheduler] Initialized. Waiting for daily job at 16:05 KST.")
+    try:
+        scheduler.start()
+    except (KeyboardInterrupt, SystemExit):
+        pass
+
+
+if __name__ == "__main__":
+    start()


### PR DESCRIPTION
## Summary
- trigger `main.main()` each weekday after market close
- document how to run the scheduler

## Testing
- `black scheduler.py`
- `flake8 .` *(fails: E501 line too long in existing files)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846f5f296d8832facb8c8e3971d43f4