### PR TITLE
[dependencies] add numpy requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy==1.26.4
 pykiwoom
 pandas
 apscheduler


### PR DESCRIPTION
## Summary
- include numpy in requirements for indicator calculations

## Testing
- `black .`
- `flake8 .`
- `pytest tests`
- `timeout 5 python main.py` *(fails: ModuleNotFoundError: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_6846fe462ca0832f9bdcd21c9166596f