### PR TITLE
[scheduler] support Python 3.8 via zoneinfo backport

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pykiwoom
 pandas
 apscheduler
 python-dotenv
+backports.zoneinfo; python_version < "3.9"

--- a/scheduler.py
+++ b/scheduler.py
@@ -2,7 +2,11 @@
 
 from apscheduler.schedulers.blocking import BlockingScheduler
 from apscheduler.triggers.cron import CronTrigger
-from zoneinfo import ZoneInfo
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:  # Python <3.9
+    from backports.zoneinfo import ZoneInfo
 
 import main
 


### PR DESCRIPTION
## Summary
- import `zoneinfo` with fallback to `backports.zoneinfo`
- include `backports.zoneinfo` in requirements

## Testing
- `black . --check`
- `flake8 .`
- `pytest -q`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_68470189505c832fb5cf9d1e4caf35ac